### PR TITLE
Add System.CodeDom collections tests

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -79,6 +79,12 @@ namespace System.Collections.Tests
         protected virtual bool ICollection_NonGeneric_SupportsSyncRoot => true;
 
         /// <summary>
+        /// Used for ICollection_NonGeneric_SyncRoot tests. Some implementations (e.g. CodeNamespaceImportCollection)
+        /// return null for the SyncRoot property of an ICollection.
+        /// </summary>
+        protected virtual bool ICollection_NonGeneric_HasNullSyncRoot => false;
+
+        /// <summary>
         /// Used for the ICollection_NonGeneric_SyncRootType_MatchesExcepted test. Most SyncRoots are created
         /// using System.Threading.Interlocked.CompareExchange(ref _syncRoot, new Object(), null)
         /// so we should test that the SyncRoot is the type we expect.
@@ -137,7 +143,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRoot_NonNull(int count)
         {
-            if (ICollection_NonGeneric_SupportsSyncRoot)
+            if (ICollection_NonGeneric_SupportsSyncRoot && ! ICollection_NonGeneric_HasNullSyncRoot)
             {
                 ICollection collection = NonGenericICollectionFactory(count);
                 Assert.NotNull(collection.SyncRoot);
@@ -146,9 +152,20 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
+        public void ICollection_NonGeneric_SyncRoot_Null(int count)
+        {
+            if (ICollection_NonGeneric_SupportsSyncRoot && ICollection_NonGeneric_HasNullSyncRoot)
+            {
+                ICollection collection = NonGenericICollectionFactory(count);
+                Assert.Null(collection.SyncRoot);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRootConsistent(int count)
         {
-            if (ICollection_NonGeneric_SupportsSyncRoot)
+            if (ICollection_NonGeneric_SupportsSyncRoot && !ICollection_NonGeneric_HasNullSyncRoot)
             {
                 ICollection collection = NonGenericICollectionFactory(count);
                 object syncRoot1 = collection.SyncRoot;
@@ -161,7 +178,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRootUnique(int count)
         {
-            if (ICollection_NonGeneric_SupportsSyncRoot)
+            if (ICollection_NonGeneric_SupportsSyncRoot && !ICollection_NonGeneric_HasNullSyncRoot)
             {
                 ICollection collection1 = NonGenericICollectionFactory(count);
                 ICollection collection2 = NonGenericICollectionFactory(count);
@@ -173,7 +190,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRoot_MatchesExpectedType(int count)
         {
-            if (ICollection_NonGeneric_SupportsSyncRoot)
+            if (ICollection_NonGeneric_SupportsSyncRoot && !ICollection_NonGeneric_HasNullSyncRoot)
             {
                 ICollection collection = NonGenericICollectionFactory(count);
 
@@ -196,7 +213,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRoot_ThrowsNotSupportedException(int count)
         {
-            if (!ICollection_NonGeneric_SupportsSyncRoot)
+            if (!ICollection_NonGeneric_SupportsSyncRoot && !ICollection_NonGeneric_HasNullSyncRoot)
             {
                 ICollection collection = NonGenericICollectionFactory(count);
                 Assert.Throws<NotSupportedException>(() => collection.SyncRoot);

--- a/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
@@ -71,6 +71,8 @@ namespace System.Collections.Tests
 
         protected virtual Type IList_NonGeneric_Item_InvalidIndex_ThrowType => typeof(ArgumentOutOfRangeException);
 
+		protected virtual bool IList_NonGeneric_RemoveNonExistent_Throws => false;
+
         #endregion
 
         #region ICollection Helper Methods
@@ -863,19 +865,34 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Remove_NonNullNotContainedInCollection(int count)
         {
-            if (!IsReadOnly && !ExpectedFixedSize)
+            if (!IsReadOnly && !ExpectedFixedSize && !IList_NonGeneric_RemoveNonExistent_Throws)
             {
                 int seed = count * 251;
-                IList collection = NonGenericIListFactory(count);
+                IList list = NonGenericIListFactory(count);
                 object value = CreateT(seed++);
-                while (collection.Contains(value) || Enumerable.Contains(InvalidValues, value))
+                while (list.Contains(value) || Enumerable.Contains(InvalidValues, value))
                     value = CreateT(seed++);
-                collection.Remove(value);
-                Assert.Equal(count, collection.Count);
+                list.Remove(value);
+                Assert.Equal(count, list.Count);
             }
-        }
+		}
 
-        [Theory]
+		[Theory]
+		[MemberData(nameof(ValidCollectionSizes))]
+		public void IList_NonGeneric_Remove_NonNullNotContainedInCollection_Throws(int count)
+		{
+			if (IList_NonGeneric_RemoveNonExistent_Throws)
+			{
+				int seed = count * 251;
+				IList list = NonGenericIListFactory(count);
+				object value = CreateT(seed++);
+				while (list.Contains(value) || Enumerable.Contains(InvalidValues, value))
+					value = CreateT(seed++);
+				Assert.Throws<ArgumentException>(() => list.Remove(value));
+			}
+		}
+
+		[Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Remove_NullContainedInCollection(int count)
         {

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/TempFiles.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/TempFiles.cs
@@ -112,7 +112,6 @@ namespace System.CodeDom.Compiler
                     _basePath = Path.Combine(
                         string.IsNullOrEmpty(TempDir) ? Path.GetTempPath() : TempDir,
                         Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
-                    string full = Path.GetFullPath(_basePath);
                     tempFileName = _basePath + ".tmp";
 
                     try
@@ -123,6 +122,10 @@ namespace System.CodeDom.Compiler
                     catch (IOException)
                     {
                         retryCount--;
+                        if (retryCount == 0)
+                        {
+                            throw;
+                        }
                         uniqueFile = false;
                     }
                 } while (!uniqueFile);

--- a/src/System.CodeDom/tests/CodeCollections/CodeAttributeArgumentCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeAttributeArgumentCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeAttributeArgumentCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeAttributeArgument[0] };
+			yield return new object[] { new CodeAttributeArgument[] { new CodeAttributeArgument() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeAttributeArgumentArray_Works(CodeAttributeArgument[] value)
+		{
+			var collection = new CodeAttributeArgumentCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeAttributeArgumentCollection_Works(CodeAttributeArgument[] value)
+		{
+			var collection = new CodeAttributeArgumentCollection(new CodeAttributeArgumentCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeAttributeArgumentArray_Works(CodeAttributeArgument[] value)
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeAttributeArgumentCollection_Works(CodeAttributeArgument[] value)
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			collection.AddRange(new CodeAttributeArgumentCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeAttributeArgumentCollection((CodeAttributeArgument[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeAttributeArgumentCollection((CodeAttributeArgumentCollection)null));
+
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeAttributeArgument[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeAttributeArgumentCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeAttributeArgumentCollection(new CodeAttributeArgument[] { null }));
+
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeAttributeArgument[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+
+			var value1 = new CodeAttributeArgument();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeAttributeArgument();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeAttributeArgument()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeAttributeArgument()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeAttributeArgument()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeAttributeArgument()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeAttributeArgumentCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeAttributeArgument());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeAttributeArgument();
+			var value2 = new CodeAttributeArgument();
+			var collection = new CodeAttributeArgumentCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeAttributeArgumentCollection collection, CodeAttributeArgument[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeAttributeArgument content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeAttributeArgument[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeAttributeDeclarationCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeAttributeDeclarationCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeAttributeDeclarationCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeAttributeDeclaration[0] };
+			yield return new object[] { new CodeAttributeDeclaration[] { new CodeAttributeDeclaration() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeAttributeDeclarationArray_Works(CodeAttributeDeclaration[] value)
+		{
+			var collection = new CodeAttributeDeclarationCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeAttributeDeclarationCollection_Works(CodeAttributeDeclaration[] value)
+		{
+			var collection = new CodeAttributeDeclarationCollection(new CodeAttributeDeclarationCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeAttributeDeclarationArray_Works(CodeAttributeDeclaration[] value)
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeAttributeDeclarationCollection_Works(CodeAttributeDeclaration[] value)
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			collection.AddRange(new CodeAttributeDeclarationCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeAttributeDeclarationCollection((CodeAttributeDeclaration[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeAttributeDeclarationCollection((CodeAttributeDeclarationCollection)null));
+
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeAttributeDeclaration[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeAttributeDeclarationCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeAttributeDeclarationCollection(new CodeAttributeDeclaration[] { null }));
+
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeAttributeDeclaration[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+
+			var value1 = new CodeAttributeDeclaration();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeAttributeDeclaration();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeAttributeDeclaration()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeAttributeDeclaration()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeAttributeDeclaration()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeAttributeDeclaration()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeAttributeDeclarationCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeAttributeDeclaration());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeAttributeDeclaration();
+			var value2 = new CodeAttributeDeclaration();
+			var collection = new CodeAttributeDeclarationCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeAttributeDeclarationCollection collection, CodeAttributeDeclaration[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeAttributeDeclaration content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeAttributeDeclaration[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeCatchClauseCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeCatchClauseCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeCatchClauseCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeCatchClause[0] };
+			yield return new object[] { new CodeCatchClause[] { new CodeCatchClause() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeCatchClauseArray_Works(CodeCatchClause[] value)
+		{
+			var collection = new CodeCatchClauseCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeCatchClauseCollection_Works(CodeCatchClause[] value)
+		{
+			var collection = new CodeCatchClauseCollection(new CodeCatchClauseCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeCatchClauseArray_Works(CodeCatchClause[] value)
+		{
+			var collection = new CodeCatchClauseCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeCatchClauseCollection_Works(CodeCatchClause[] value)
+		{
+			var collection = new CodeCatchClauseCollection();
+			collection.AddRange(new CodeCatchClauseCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeCatchClauseCollection((CodeCatchClause[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeCatchClauseCollection((CodeCatchClauseCollection)null));
+
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeCatchClause[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeCatchClauseCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeCatchClauseCollection(new CodeCatchClause[] { null }));
+
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeCatchClause[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeCatchClauseCollection();
+
+			var value1 = new CodeCatchClause();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeCatchClause();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeCatchClause()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeCatchClause()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeCatchClause()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeCatchClause()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeCatchClauseCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeCatchClause());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeCatchClause();
+			var value2 = new CodeCatchClause();
+			var collection = new CodeCatchClauseCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeCatchClauseCollection collection, CodeCatchClause[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeCatchClause content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeCatchClause[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeCommentStatementCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeCommentStatementCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeCommentStatementCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeCommentStatement[0] };
+			yield return new object[] { new CodeCommentStatement[] { new CodeCommentStatement() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeCommentStatementArray_Works(CodeCommentStatement[] value)
+		{
+			var collection = new CodeCommentStatementCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeCommentStatementCollection_Works(CodeCommentStatement[] value)
+		{
+			var collection = new CodeCommentStatementCollection(new CodeCommentStatementCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeCommentStatementArray_Works(CodeCommentStatement[] value)
+		{
+			var collection = new CodeCommentStatementCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeCommentStatementCollection_Works(CodeCommentStatement[] value)
+		{
+			var collection = new CodeCommentStatementCollection();
+			collection.AddRange(new CodeCommentStatementCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeCommentStatementCollection((CodeCommentStatement[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeCommentStatementCollection((CodeCommentStatementCollection)null));
+
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeCommentStatement[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeCommentStatementCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeCommentStatementCollection(new CodeCommentStatement[] { null }));
+
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeCommentStatement[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeCommentStatementCollection();
+
+			var value1 = new CodeCommentStatement();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeCommentStatement();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeCommentStatement()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeCommentStatement()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeCommentStatement()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeCommentStatement()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeCommentStatementCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeCommentStatement());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeCommentStatement();
+			var value2 = new CodeCommentStatement();
+			var collection = new CodeCommentStatementCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeCommentStatementCollection collection, CodeCommentStatement[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeCommentStatement content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeCommentStatement[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeDirectiveCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeDirectiveCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeDirectiveCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeDirective[0] };
+			yield return new object[] { new CodeDirective[] { new CodeDirective() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeDirectiveArray_Works(CodeDirective[] value)
+		{
+			var collection = new CodeDirectiveCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeDirectiveCollection_Works(CodeDirective[] value)
+		{
+			var collection = new CodeDirectiveCollection(new CodeDirectiveCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeDirectiveArray_Works(CodeDirective[] value)
+		{
+			var collection = new CodeDirectiveCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeDirectiveCollection_Works(CodeDirective[] value)
+		{
+			var collection = new CodeDirectiveCollection();
+			collection.AddRange(new CodeDirectiveCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeDirectiveCollection((CodeDirective[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeDirectiveCollection((CodeDirectiveCollection)null));
+
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeDirective[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeDirectiveCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeDirectiveCollection(new CodeDirective[] { null }));
+
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeDirective[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeDirectiveCollection();
+
+			var value1 = new CodeDirective();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeDirective();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeDirective()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeDirective()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeDirective()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeDirective()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeDirectiveCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeDirective());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeDirective();
+			var value2 = new CodeDirective();
+			var collection = new CodeDirectiveCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeDirectiveCollection collection, CodeDirective[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeDirective content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeDirective[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeExpressionCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeExpressionCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeExpressionCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeExpression[0] };
+			yield return new object[] { new CodeExpression[] { new CodeExpression() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeExpressionArray_Works(CodeExpression[] value)
+		{
+			var collection = new CodeExpressionCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeExpressionCollection_Works(CodeExpression[] value)
+		{
+			var collection = new CodeExpressionCollection(new CodeExpressionCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeExpressionArray_Works(CodeExpression[] value)
+		{
+			var collection = new CodeExpressionCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeExpressionCollection_Works(CodeExpression[] value)
+		{
+			var collection = new CodeExpressionCollection();
+			collection.AddRange(new CodeExpressionCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeExpressionCollection((CodeExpression[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeExpressionCollection((CodeExpressionCollection)null));
+
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeExpression[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeExpressionCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeExpressionCollection(new CodeExpression[] { null }));
+
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeExpression[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeExpressionCollection();
+
+			var value1 = new CodeExpression();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeExpression();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeExpression()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeExpression()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeExpression()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeExpression()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeExpressionCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeExpression());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeExpression();
+			var value2 = new CodeExpression();
+			var collection = new CodeExpressionCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeExpressionCollection collection, CodeExpression[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeExpression content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeExpression[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeNamespaceCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeNamespaceCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeNamespaceCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeNamespace[0] };
+			yield return new object[] { new CodeNamespace[] { new CodeNamespace() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeNamespaceArray_Works(CodeNamespace[] value)
+		{
+			var collection = new CodeNamespaceCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeNamespaceCollection_Works(CodeNamespace[] value)
+		{
+			var collection = new CodeNamespaceCollection(new CodeNamespaceCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeNamespaceArray_Works(CodeNamespace[] value)
+		{
+			var collection = new CodeNamespaceCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeNamespaceCollection_Works(CodeNamespace[] value)
+		{
+			var collection = new CodeNamespaceCollection();
+			collection.AddRange(new CodeNamespaceCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeNamespaceCollection((CodeNamespace[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeNamespaceCollection((CodeNamespaceCollection)null));
+
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeNamespace[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeNamespaceCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeNamespaceCollection(new CodeNamespace[] { null }));
+
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeNamespace[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeNamespaceCollection();
+
+			var value1 = new CodeNamespace();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeNamespace();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeNamespace()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeNamespace()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeNamespace()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeNamespace()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeNamespaceCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeNamespace());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeNamespace();
+			var value2 = new CodeNamespace();
+			var collection = new CodeNamespaceCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeNamespaceCollection collection, CodeNamespace[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeNamespace content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeNamespace[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeNamespaceImportCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeNamespaceImportCollectionTests.cs
@@ -1,0 +1,136 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Tests;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+    public class CodeNamespaceImportCollectionTests : IList_NonGeneric_Tests
+    {
+        protected override IList NonGenericIListFactory() => new CodeNamespaceImportCollection();
+
+        protected override object CreateT(int seed) => new CodeNamespaceImport(seed.ToString());
+
+        protected override bool NullAllowed => false;
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override bool ICollection_NonGeneric_HasNullSyncRoot => true;
+
+        protected override Type ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ThrowType => typeof(ArgumentOutOfRangeException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+
+        [Fact]
+        public void Add()
+        {
+            var collection = new CodeNamespaceImportCollection();
+            var value = new CodeNamespaceImport();
+
+            collection.Add(value);
+            Assert.Equal(1, collection.Count);
+            Assert.Same(value, collection[0]);
+        }
+
+        [Fact]
+        public void Add_SameNamespace_DoesntAdd()
+        {
+            var collection = new CodeNamespaceImportCollection();
+            var value1 = new CodeNamespaceImport("Namespace");
+            collection.Add(value1);
+
+            collection.Add(value1);
+            Assert.Equal(1, collection.Count);
+
+            var value2 = new CodeNamespaceImport("Namespace");
+            collection.Add(value2);
+            Assert.Equal(1, collection.Count);
+        }
+
+        [Fact]
+        public void Add_Null_ThrowsNullReferenceException()
+        {
+            var collection = new CodeNamespaceImportCollection();
+            Assert.Throws<NullReferenceException>(() => collection.Add(null));
+        }
+
+        public static IEnumerable<object[]> AddRange_TestData()
+        {
+            yield return new object[] { new CodeNamespaceImport[0] };
+            yield return new object[] { new CodeNamespaceImport[] { new CodeNamespaceImport() } };
+        }
+
+        [Theory]
+        [MemberData(nameof(AddRange_TestData))]
+        public void AddRange_CodeNamespaceArray_Works(CodeNamespaceImport[] value)
+        {
+            var collection = new CodeNamespaceImportCollection();
+            collection.AddRange(value);
+            Assert.Equal(value.Length, collection.Count);
+            for (int i = 0; i < value.Length; i++)
+            {
+                Assert.Same(value[i], collection[i]);
+            }
+        }
+
+        [Fact]
+        public void AddRange_Null_ThrowsArgumentNullException()
+        {
+            var collection = new CodeNamespaceImportCollection();
+            Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
+            Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
+        }
+
+        [Fact]
+        public void AddRange_NullObjectInValue_ThrowsNullReferenceException()
+        {
+            var collection = new CodeNamespaceImportCollection();
+            Assert.Throws<NullReferenceException>(() => collection.AddRange(new CodeNamespaceImport[] { null }));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var collection = new CodeNamespaceCollection();
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeNamespace());
+        }
+
+        [Fact]
+        public void ItemSet_Get_ReturnsExpected()
+        {
+            var value1 = new CodeNamespace();
+            var value2 = new CodeNamespace();
+            var collection = new CodeNamespaceCollection();
+            collection.Add(value1);
+
+            collection[0] = value2;
+            Assert.Equal(1, collection.Count);
+            Assert.Same(value2, collection[0]);
+        }
+
+        private static void VerifyCollection(CodeNamespaceCollection collection, CodeNamespace[] contents)
+        {
+            Assert.Equal(contents.Length, collection.Count);
+            for (int i = 0; i < contents.Length; i++)
+            {
+                CodeNamespace content = contents[i];
+                Assert.Equal(i, collection.IndexOf(content));
+                Assert.True(collection.Contains(content));
+                Assert.Same(content, collection[i]);
+            }
+
+            const int Index = 1;
+            var copy = new CodeNamespace[collection.Count + Index];
+            collection.CopyTo(copy, Index);
+            Assert.Null(copy[0]);
+            for (int i = Index; i < copy.Length; i++)
+            {
+                Assert.Same(contents[i - Index], copy[i]);
+            }
+        }
+    }
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeParameterDeclarationExpressionCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeParameterDeclarationExpressionCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeParameterDeclarationExpressionCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeParameterDeclarationExpression[0] };
+			yield return new object[] { new CodeParameterDeclarationExpression[] { new CodeParameterDeclarationExpression() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeParameterDeclarationExpressionArray_Works(CodeParameterDeclarationExpression[] value)
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeParameterDeclarationExpressionCollection_Works(CodeParameterDeclarationExpression[] value)
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection(new CodeParameterDeclarationExpressionCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeParameterDeclarationExpressionArray_Works(CodeParameterDeclarationExpression[] value)
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeParameterDeclarationExpressionCollection_Works(CodeParameterDeclarationExpression[] value)
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			collection.AddRange(new CodeParameterDeclarationExpressionCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeParameterDeclarationExpressionCollection((CodeParameterDeclarationExpression[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeParameterDeclarationExpressionCollection((CodeParameterDeclarationExpressionCollection)null));
+
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeParameterDeclarationExpression[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeParameterDeclarationExpressionCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeParameterDeclarationExpressionCollection(new CodeParameterDeclarationExpression[] { null }));
+
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeParameterDeclarationExpression[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+
+			var value1 = new CodeParameterDeclarationExpression();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeParameterDeclarationExpression();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeParameterDeclarationExpression()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeParameterDeclarationExpression()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeParameterDeclarationExpression()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeParameterDeclarationExpression()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeParameterDeclarationExpression());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeParameterDeclarationExpression();
+			var value2 = new CodeParameterDeclarationExpression();
+			var collection = new CodeParameterDeclarationExpressionCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeParameterDeclarationExpressionCollection collection, CodeParameterDeclarationExpression[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeParameterDeclarationExpression content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeParameterDeclarationExpression[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeStatementCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeStatementCollectionTests.cs
@@ -1,0 +1,213 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeStatementCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeStatement[0] };
+			yield return new object[] { new CodeStatement[] { new CodeStatement() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeStatementArray_Works(CodeStatement[] value)
+		{
+			var collection = new CodeStatementCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeStatementCollection_Works(CodeStatement[] value)
+		{
+			var collection = new CodeStatementCollection(new CodeStatementCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeStatementArray_Works(CodeStatement[] value)
+		{
+			var collection = new CodeStatementCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeStatementCollection_Works(CodeStatement[] value)
+		{
+			var collection = new CodeStatementCollection();
+			collection.AddRange(new CodeStatementCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeStatementCollection((CodeStatement[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeStatementCollection((CodeStatementCollection)null));
+
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeStatement[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeStatementCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeStatementCollection(new CodeStatement[] { null }));
+
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeStatement[] { null }));
+		}
+
+		[Fact]
+		public void Add_CodeStatement_Insert_Remove()
+		{
+			var collection = new CodeStatementCollection();
+
+			var value1 = new CodeStatement();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeStatement();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> Add_CodeExpression_TestData()
+		{
+			yield return new object[] { null };
+			yield return new object[] { new CodePrimitiveExpression("Value") };
+		}
+
+		[Theory]
+		[MemberData(nameof(Add_CodeExpression_TestData))]
+		public void Add_CodeExpression(CodeExpression expression)
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Equal(0, collection.Add(expression));
+			Assert.Equal(expression, ((CodeExpressionStatement)collection[0]).Expression);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add((CodeStatement)null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeStatement()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeStatement()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeStatement()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeStatement()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeStatementCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeStatement());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeStatement();
+			var value2 = new CodeStatement();
+			var collection = new CodeStatementCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeStatementCollection collection, CodeStatement[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeStatement content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeStatement[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeTypeDeclarationCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeTypeDeclarationCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeTypeDeclarationCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeTypeDeclaration[0] };
+			yield return new object[] { new CodeTypeDeclaration[] { new CodeTypeDeclaration() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeTypeDeclarationArray_Works(CodeTypeDeclaration[] value)
+		{
+			var collection = new CodeTypeDeclarationCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeTypeDeclarationCollection_Works(CodeTypeDeclaration[] value)
+		{
+			var collection = new CodeTypeDeclarationCollection(new CodeTypeDeclarationCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeDeclarationArray_Works(CodeTypeDeclaration[] value)
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeDeclarationCollection_Works(CodeTypeDeclaration[] value)
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			collection.AddRange(new CodeTypeDeclarationCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeDeclarationCollection((CodeTypeDeclaration[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeDeclarationCollection((CodeTypeDeclarationCollection)null));
+
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeDeclaration[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeDeclarationCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeDeclarationCollection(new CodeTypeDeclaration[] { null }));
+
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeTypeDeclaration[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+
+			var value1 = new CodeTypeDeclaration();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeTypeDeclaration();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeTypeDeclaration()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeTypeDeclaration()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeTypeDeclaration()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeTypeDeclaration()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeDeclarationCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeTypeDeclaration());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeTypeDeclaration();
+			var value2 = new CodeTypeDeclaration();
+			var collection = new CodeTypeDeclarationCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeTypeDeclarationCollection collection, CodeTypeDeclaration[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeTypeDeclaration content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeTypeDeclaration[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeTypeMemberCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeTypeMemberCollectionTests.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeTypeMemberCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeTypeMember[0] };
+			yield return new object[] { new CodeTypeMember[] { new CodeTypeMember() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeTypeMemberArray_Works(CodeTypeMember[] value)
+		{
+			var collection = new CodeTypeMemberCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeTypeMemberCollection_Works(CodeTypeMember[] value)
+		{
+			var collection = new CodeTypeMemberCollection(new CodeTypeMemberCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeMemberArray_Works(CodeTypeMember[] value)
+		{
+			var collection = new CodeTypeMemberCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeMemberCollection_Works(CodeTypeMember[] value)
+		{
+			var collection = new CodeTypeMemberCollection();
+			collection.AddRange(new CodeTypeMemberCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeMemberCollection((CodeTypeMember[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeMemberCollection((CodeTypeMemberCollection)null));
+
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeMember[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeMemberCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeMemberCollection(new CodeTypeMember[] { null }));
+
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeTypeMember[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CodeTypeMemberCollection();
+
+			var value1 = new CodeTypeMember();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeTypeMember();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeTypeMember()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeTypeMember()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeTypeMember()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeTypeMember()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeMemberCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeTypeMember());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeTypeMember();
+			var value2 = new CodeTypeMember();
+			var collection = new CodeTypeMemberCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeTypeMemberCollection collection, CodeTypeMember[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeTypeMember content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeTypeMember[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeTypeParameterCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeTypeParameterCollectionTests.cs
@@ -1,0 +1,209 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeTypeParameterCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeTypeParameter[0] };
+			yield return new object[] { new CodeTypeParameter[] { new CodeTypeParameter() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeTypeParameterArray_Works(CodeTypeParameter[] value)
+		{
+			var collection = new CodeTypeParameterCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeTypeParameterCollection_Works(CodeTypeParameter[] value)
+		{
+			var collection = new CodeTypeParameterCollection(new CodeTypeParameterCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeParameterArray_Works(CodeTypeParameter[] value)
+		{
+			var collection = new CodeTypeParameterCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeParameterCollection_Works(CodeTypeParameter[] value)
+		{
+			var collection = new CodeTypeParameterCollection();
+			collection.AddRange(new CodeTypeParameterCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeParameterCollection((CodeTypeParameter[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeParameterCollection((CodeTypeParameterCollection)null));
+
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeParameter[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeParameterCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeParameterCollection(new CodeTypeParameter[] { null }));
+
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeTypeParameter[] { null }));
+		}
+
+		[Fact]
+		public void Add_CodeTypeParameter_Insert_Remove()
+		{
+			var collection = new CodeTypeParameterCollection();
+
+			var value1 = new CodeTypeParameter();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeTypeParameter();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[InlineData("Name")]
+		public void Add_String(string name)
+		{
+			var collection = new CodeTypeParameterCollection();
+			collection.Add(name);
+			Assert.Equal(new CodeTypeParameter(name).Name, collection[0].Name);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add((CodeTypeParameter)null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeTypeParameter()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeTypeParameter()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeTypeParameter()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeTypeParameter()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeParameterCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeTypeParameter());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeTypeParameter();
+			var value2 = new CodeTypeParameter();
+			var collection = new CodeTypeParameterCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeTypeParameterCollection collection, CodeTypeParameter[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeTypeParameter content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeTypeParameter[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CodeTypeReferenceCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeTypeReferenceCollectionTests.cs
@@ -1,0 +1,219 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CodeTypeReferenceCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CodeTypeReference[0] };
+			yield return new object[] { new CodeTypeReference[] { new CodeTypeReference() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CodeTypeReferenceArray_Works(CodeTypeReference[] value)
+		{
+			var collection = new CodeTypeReferenceCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CodeTypeReferenceCollection_Works(CodeTypeReference[] value)
+		{
+			var collection = new CodeTypeReferenceCollection(new CodeTypeReferenceCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeReferenceArray_Works(CodeTypeReference[] value)
+		{
+			var collection = new CodeTypeReferenceCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CodeTypeReferenceCollection_Works(CodeTypeReference[] value)
+		{
+			var collection = new CodeTypeReferenceCollection();
+			collection.AddRange(new CodeTypeReferenceCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeReferenceCollection((CodeTypeReference[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeReferenceCollection((CodeTypeReferenceCollection)null));
+
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeReference[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CodeTypeReferenceCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CodeTypeReferenceCollection(new CodeTypeReference[] { null }));
+
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CodeTypeReference[] { null }));
+		}
+
+		[Fact]
+		public void Add_CodeTypeReference_Insert_Remove()
+		{
+			var collection = new CodeTypeReferenceCollection();
+
+			var value1 = new CodeTypeReference();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CodeTypeReference();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[InlineData("System.Int32")]
+		public void Add_String(string type)
+		{
+			var collection = new CodeTypeReferenceCollection();
+			collection.Add(type);
+			Assert.Equal(new CodeTypeReference(type).BaseType, collection[0].BaseType);
+		}
+
+		[Theory]
+		[InlineData(typeof(int))]
+		public void Add_Type(Type type)
+		{
+			var collection = new CodeTypeReferenceCollection();
+			collection.Add(type);
+			Assert.Equal(new CodeTypeReference(type).BaseType, collection[0].BaseType);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add((CodeTypeReference)null));
+			Assert.Throws<ArgumentNullException>("type", () => collection.Add((Type)null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CodeTypeReference()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CodeTypeReference()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CodeTypeReference()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CodeTypeReference()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CodeTypeReferenceCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CodeTypeReference());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CodeTypeReference();
+			var value2 = new CodeTypeReference();
+			var collection = new CodeTypeReferenceCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CodeTypeReferenceCollection collection, CodeTypeReference[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CodeTypeReference content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CodeTypeReference[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/CompilerErrorCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CompilerErrorCollectionTests.cs
@@ -175,6 +175,70 @@ namespace System.CodeDom.Tests
 			Assert.Same(value2, collection[0]);
 		}
 
+		[Fact]
+		public void HasWarnings_Empty_ReturnsFalse()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.False(collection.HasWarnings);
+		}
+
+		[Fact]
+		public void HasWarnings_OnlyErrors_ReturnsFalse()
+		{
+			var collection = new CompilerErrorCollection();
+			collection.Add(new CompilerError() { IsWarning = false });
+			Assert.False(collection.HasWarnings);
+		}
+
+		[Fact]
+		public void HasWarnings_OnlyWarnings_ReturnsTrue()
+		{
+			var collection = new CompilerErrorCollection();
+			collection.Add(new CompilerError() { IsWarning = true });
+			Assert.True(collection.HasWarnings);
+		}
+
+		[Fact]
+		public void HasWarnings_WarningsAndErrors_ReturnsTrue()
+		{
+			var collection = new CompilerErrorCollection();
+			collection.Add(new CompilerError() { IsWarning = false });
+			collection.Add(new CompilerError() { IsWarning = true });
+			Assert.True(collection.HasWarnings);
+		}
+
+		[Fact]
+		public void HasErrors_Empty_ReturnsFalse()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.False(collection.HasErrors);
+		}
+
+		[Fact]
+		public void HasErrors_OnlyErrors_ReturnsTrue()
+		{
+			var collection = new CompilerErrorCollection();
+			collection.Add(new CompilerError() { IsWarning = false });
+			Assert.True(collection.HasErrors);
+		}
+
+		[Fact]
+		public void HasErrors_OnlyWarnings_ReturnsFalse()
+		{
+			var collection = new CompilerErrorCollection();
+			collection.Add(new CompilerError() { IsWarning = true });
+			Assert.False(collection.HasErrors);
+		}
+
+		[Fact]
+		public void HasErrors_WarningsAndErrors_ReturnsTrue()
+		{
+			var collection = new CompilerErrorCollection();
+			collection.Add(new CompilerError() { IsWarning = false });
+			collection.Add(new CompilerError() { IsWarning = true });
+			Assert.True(collection.HasErrors);
+		}
+
 		private static void VerifyCollection(CompilerErrorCollection collection, CompilerError[] contents)
 		{
 			Assert.Equal(contents.Length, collection.Count);

--- a/src/System.CodeDom/tests/CodeCollections/CompilerErrorCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CompilerErrorCollectionTests.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class CompilerErrorCollectionTests
+	{
+		[Fact]
+		public void Ctor_IsEmpty()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Equal(0, collection.Count);
+		}
+
+		public static IEnumerable<object[]> AddRange_TestData()
+		{
+			yield return new object[] { new CompilerError[0] };
+			yield return new object[] { new CompilerError[] { new CompilerError() } };
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor__CompilerErrorArray_Works(CompilerError[] value)
+		{
+			var collection = new CompilerErrorCollection(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void Ctor_CompilerErrorCollection_Works(CompilerError[] value)
+		{
+			var collection = new CompilerErrorCollection(new CompilerErrorCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CompilerErrorArray_Works(CompilerError[] value)
+		{
+			var collection = new CompilerErrorCollection();
+			collection.AddRange(value);
+			VerifyCollection(collection, value);
+		}
+
+		[Theory]
+		[MemberData(nameof(AddRange_TestData))]
+		public void AddRange_CompilerErrorCollection_Works(CompilerError[] value)
+		{
+			var collection = new CompilerErrorCollection();
+			collection.AddRange(new CompilerErrorCollection(value));
+			VerifyCollection(collection, value);
+		}
+
+		[Fact]
+		public void AddRange_Null_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CompilerErrorCollection((CompilerError[])null));
+			Assert.Throws<ArgumentNullException>("value", () => new CompilerErrorCollection((CompilerErrorCollection)null));
+
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CompilerError[])null));
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange((CompilerErrorCollection)null));
+		}
+
+		[Fact]
+		public void AddRange_NullObjectInValue_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>("value", () => new CompilerErrorCollection(new CompilerError[] { null }));
+
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(new CompilerError[] { null }));
+		}
+
+		[Fact]
+		public void Add_Insert_Remove()
+		{
+			var collection = new CompilerErrorCollection();
+
+			var value1 = new CompilerError();
+			Assert.Equal(0, collection.Add(value1));
+			Assert.Equal(1, collection.Count);
+			Assert.Equal(value1, collection[0]);
+
+			var value2 = new CompilerError();
+			collection.Insert(0, value2);
+			Assert.Equal(2, collection.Count);
+			Assert.Same(value2, collection[0]);
+
+			collection.Remove(value1);
+			Assert.Equal(1, collection.Count);
+
+			collection.Remove(value2);
+			Assert.Equal(0, collection.Count);
+		}
+
+		[Fact]
+		public void Add_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Add(null));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(1)]
+		public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, new CompilerError()));
+		}
+
+		[Fact]
+		public void Insert_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+		}
+
+		[Fact]
+		public void Remove_Null_ThrowsArgumentNullException()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+		}
+
+		[Fact]
+		public void Remove_NoSuchObject_ThrowsArgumentException()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentException>(null, () => collection.Remove(new CompilerError()));
+		}
+
+		[Fact]
+		public void Contains_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.False(collection.Contains(null));
+			Assert.False(collection.Contains(new CompilerError()));
+		}
+
+		[Fact]
+		public void IndexOf_NoSuchObject_ReturnsMinusOne()
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Equal(-1, collection.IndexOf(null));
+			Assert.Equal(-1, collection.IndexOf(new CompilerError()));
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public void Item_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+		{
+			var collection = new CompilerErrorCollection();
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
+			Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = new CompilerError());
+		}
+
+		[Fact]
+		public void ItemSet_Get_ReturnsExpected()
+		{
+			var value1 = new CompilerError();
+			var value2 = new CompilerError();
+			var collection = new CompilerErrorCollection();
+			collection.Add(value1);
+
+			collection[0] = value2;
+			Assert.Equal(1, collection.Count);
+			Assert.Same(value2, collection[0]);
+		}
+
+		private static void VerifyCollection(CompilerErrorCollection collection, CompilerError[] contents)
+		{
+			Assert.Equal(contents.Length, collection.Count);
+			for (int i = 0; i < contents.Length; i++)
+			{
+				CompilerError content = contents[i];
+				Assert.Equal(i, collection.IndexOf(content));
+				Assert.True(collection.Contains(content));
+				Assert.Same(content, collection[i]);
+			}
+
+			const int Index = 1;
+			var copy = new CompilerError[collection.Count + Index];
+			collection.CopyTo(copy, Index);
+			Assert.Null(copy[0]);
+			for (int i = Index; i < copy.Length; i++)
+			{
+				Assert.Same(contents[i - Index], copy[i]);
+			}
+		}
+	}
+}

--- a/src/System.CodeDom/tests/CodeCollections/TempFileCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/TempFileCollectionTests.cs
@@ -1,0 +1,227 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom.Compiler;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Tests;
+using System.IO;
+using Xunit;
+
+namespace System.CodeDom.Tests
+{
+	public class TempFileCollectionTests : ICollection_NonGeneric_Tests
+	{
+        protected override ICollection NonGenericICollectionFactory() => new TempFileCollection();
+
+        protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
+        {
+            Random random = new Random(numberOfItemsToAdd);
+            for (int i = 0; i < numberOfItemsToAdd; i++)
+            {
+                ((TempFileCollection)collection).AddFile(random.Next().ToString(), keepFile: true);
+            }
+        }
+
+        protected override bool NullAllowed => false;
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override bool ICollection_NonGeneric_HasNullSyncRoot => true;
+        
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
+
+        public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
+        {
+            ICollection collection = NonGenericICollectionFactory(count);
+            Array arr = Array.CreateInstance(typeof(object), new int[1] { count }, new int[1] { 2 });
+
+            if (count == 0)
+            {
+                collection.CopyTo(arr, 0);
+            }
+            else
+            {
+                Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(arr, 0));
+            }
+        }
+
+        [Fact]
+		public void Ctor_Empty()
+		{
+			var collection = new TempFileCollection();
+			Assert.Equal(0, collection.Count);
+			Assert.Empty(collection.TempDir);
+			Assert.False(collection.KeepFiles);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[InlineData("TempDir")]
+		public void Ctor_String(string tempDir)
+		{
+			var collection = new TempFileCollection(tempDir);
+			Assert.Equal(0, collection.Count);
+			Assert.Equal(tempDir ?? string.Empty, collection.TempDir);
+			Assert.False(collection.KeepFiles);
+		}
+
+		[Theory]
+		[InlineData(null, false)]
+		[InlineData("", true)]
+		[InlineData("TempDir", false)]
+		public void Ctor_String_Bool(string tempDir, bool keepFiles)
+		{
+			var collection = new TempFileCollection(tempDir, keepFiles);
+			Assert.Equal(0, collection.Count);
+			Assert.Equal(tempDir ?? string.Empty, collection.TempDir);
+			Assert.Equal(keepFiles, collection.KeepFiles);
+		}
+
+		public static IEnumerable<object[]> BasePath_TestData()
+		{
+			yield return new object[] { "NoSuchDirectory" };
+			yield return new object[] { TempDirectory() };
+		}
+
+		[Theory]
+		[MemberData(nameof(BasePath_TestData))]
+		public void BasePath_Get(string tempDir)
+		{
+			var collection = new TempFileCollection(tempDir);
+			if (Directory.Exists(tempDir))
+			{
+				Assert.StartsWith(tempDir, collection.BasePath);
+			}
+			else
+			{
+				Assert.Throws<DirectoryNotFoundException>(() => collection.BasePath);
+				Assert.StartsWith(tempDir, collection.BasePath);
+			}
+        }
+
+        [Fact]
+        public void AddFileExtension()
+        {
+            string tempDirectory = TempDirectory();
+            using (var collection = new TempFileCollection(tempDirectory))
+            {
+                string file = collection.AddExtension("txt");
+                Assert.False(File.Exists(file));
+                Assert.Equal(collection.BasePath + "." + "txt", file);
+            }
+        }
+
+        [Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		public void AddExtension_InvalidFileExtension_ThrowsArgumentException(string fileExtension)
+		{
+			using (var collection = new TempFileCollection())
+			{
+				Assert.Throws<ArgumentException>("fileExtension", () => collection.AddExtension(fileExtension));
+				Assert.Throws<ArgumentException>("fileExtension", () => collection.AddExtension(fileExtension, keepFile: false));
+			}
+        }
+
+        [Theory]
+		[InlineData(true, true)]
+		[InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void AddFile(bool fileExists, bool keepFile)
+		{
+			string directory = TempDirectory();
+			const string FileName = "file.extension";
+			string filePath = Path.Combine(directory, FileName);
+            if (fileExists)
+            {
+                File.Create(filePath).Dispose();
+            }
+			try
+			{
+				using (var collection = new TempFileCollection(directory))
+				{
+                    // AddFile(fileName) is a misnomer, and should really be AddFile(filePath),
+                    // as only files added with their full path are deleted.
+					collection.AddFile(filePath, keepFile);
+					Assert.Equal(fileExists, File.Exists(filePath));
+				}
+				
+				Assert.Equal(fileExists && keepFile, File.Exists(filePath));
+			}
+			finally
+			{
+				if (File.Exists(filePath))
+				{
+					File.Delete(filePath);
+				}
+			}
+        }
+
+        [Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		public void AddFile_InvalidFileName_ThrowsArgumentException(string fileName)
+		{
+			using (var collection = new TempFileCollection())
+			{
+				Assert.Throws<ArgumentException>("fileName", () => collection.AddFile(fileName, keepFile: false));
+			}
+		}
+
+		[Fact]
+		public void AddFile_DuplicateFileName_ThrowsArgumentException()
+		{
+			using (var collection = new TempFileCollection())
+			{
+				const string FileName = "FileName";
+				collection.AddFile(FileName, keepFile: false);
+				Assert.Throws<ArgumentException>("fileName", () => collection.AddFile(FileName, keepFile: false));
+
+				// Case insensitive
+				Assert.Throws<ArgumentException>("fileName", () => collection.AddFile(FileName.ToLowerInvariant(), keepFile: false));
+			}
+		}
+
+        [Fact]
+        public void GetEnumerator_Empty_ReturnsFalse()
+        {
+            using (var collection = new TempFileCollection())
+            {
+                Assert.False(collection.GetEnumerator().MoveNext());
+            }
+        }
+
+        [Fact]
+        public void CopyTo()
+        {
+            using (var collection = new TempFileCollection())
+            {
+                const int ArrayIndex = 1;
+                const string FileName = "File";
+                collection.AddFile(FileName, keepFile: false);
+
+                var array = new string[ArrayIndex + collection.Count];
+                collection.CopyTo(array, ArrayIndex);
+
+                Assert.Null(array[0]);
+                Assert.Equal(FileName, array[ArrayIndex]);
+            }
+        }
+
+        private static string s_tempDirectory = null;
+		private static string TempDirectory()
+		{
+			if (s_tempDirectory == null)
+			{
+				string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+				Directory.CreateDirectory(tempDirectory);
+				s_tempDirectory = tempDirectory;
+			}
+			return s_tempDirectory;
+		}
+    }
+}

--- a/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
+++ b/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
@@ -9,6 +9,22 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="CodeCollections\CodeAttributeDeclarationCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeAttributeArgumentCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeCatchClauseCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeCommentStatementCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeDirectiveCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeExpressionCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeNamespaceCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeNamespaceImportCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeParameterDeclarationExpressionCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeStatementCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeTypeDeclarationCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeTypeMemberCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeTypeParameterCollectionTests.cs" />
+    <Compile Include="CodeCollections\CodeTypeReferenceCollectionTests.cs" />
+    <Compile Include="CodeCollections\CompilerErrorCollectionTests.cs" />
+    <Compile Include="CodeCollections\TempFileCollectionTests.cs" />
     <Compile Include="CodeExpressions\CodeObjectCreateExpressionTests.cs" />
     <Compile Include="CodeExpressions\CodeParameterDeclarationExpressionTests.cs" />
     <Compile Include="CodeExpressions\CodeMethodReferenceExpressionTests.cs" />

--- a/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
+++ b/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
@@ -92,6 +92,18 @@
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+      <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+      <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+      <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+      <Link>Common\System\Collections\TestBase.NonGeneric.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.CodeDom.pkgproj">


### PR DESCRIPTION
Unfortunately, there is a lot of code duplication in the first commit.
This is because each collection uses CollectionBase, so defines its own methods that are strongly typed. As such, there is no way to have common tests that run generically for all of the collections. The IList and ICollection helpers cannot help here, as none of the collections actually implement IList/ICollection.

In the second commit, I fixed a porting bug in TempFileCollection. This meant that if we tried to add a file extension or access properties on TempFileCollection when passing a non-existent directory, we would recurse forever into oblivion.
See the reference source [here](https://referencesource.microsoft.com/#System/compmod/system/codedom/compiler/TempFiles.cs,208) compared to our code in corefx [here](https://github.com/dotnet/corefx/blob/master/src/System.CodeDom/src/System/CodeDom/Compiler/TempFiles.cs#L125)

I also removed an unused variable in that methd


Part of #12179

/cc @stephentoub